### PR TITLE
Remove rating multiplier from corkscrew trains

### DIFF
--- a/ride/rct1.ride.corkscrew_trains/object.json
+++ b/ride/rct1.ride.corkscrew_trains/object.json
@@ -13,9 +13,6 @@
         "maxCarsPerTrain": 8,
         "defaultCar": 1,
         "headCars": 0,
-        "ratingMultipler": {
-            "intensity": 10
-        },
         "carColours": [
             [
                 ["bright_red", "white", "black"]


### PR DESCRIPTION
Oddly enough the corkscrew trains don't seem to have had this in RCT1. Leaving it on our custom reversed trains for now as those need a little more work for their rating multipliers.
"Corkscrew" from the RCT1 base game's pre-built tracks in RCT1 and after this change.
![Screenshot_select-area_20221019100933](https://user-images.githubusercontent.com/42477864/196717588-a216143d-3db9-49dd-b74a-29cbb3f6d847.png)
![Screenshot_select-area_20221019100941](https://user-images.githubusercontent.com/42477864/196717592-76ae568f-ef8a-4982-8823-a104bd419b43.png)
