### PR TITLE
Lower racing cars rating multiplier to 1

### DIFF
--- a/ride/rct1.ride.racing_cars/object.json
+++ b/ride/rct1.ride.racing_cars/object.json
@@ -16,7 +16,7 @@
         "headCars": 1,
         "tailCars": 1,
         "ratingMultipler": {
-            "excitement": 3
+            "excitement": 1
         },
         "carColours": [
             [


### PR DESCRIPTION
This is what the rating multiplier seems to be for the racing cars in RCT1, all of the other car rides still seem to just have no rating multiplier like in RCT2.